### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Drag ```UIButton+tintImage.h``` and ```UIButton+tintImage.m```.
 
 ## Usage
 ```objective-c
-#import UIButton+tintImage.h
+# import UIButton+tintImage.h
 
 // Tint single buttons
 [button setImageTintColor:[UIColor redColor] forState:UIControlStateNormal];


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
